### PR TITLE
Improve initial isVisible prop check

### DIFF
--- a/src/FocusLoop.vue
+++ b/src/FocusLoop.vue
@@ -46,7 +46,7 @@ export default defineComponent({
     const getTabindex = computed((): number => props.disabled ? -1 : 0)
     watch(() => props.isVisible, focusFirst)
 
-    onMounted(() => focusFirst(props.isVisible || true))
+    onMounted(() => focusFirst(props.isVisible !== null && props.isVisible !== undefined ? props.isVisible : true))
 
     function focusFirst (visible: boolean): void {
       if (visible) {


### PR DESCRIPTION
Short circuiting the isVisible prop will always lead to the fallback value (true) as false will always be skipped and therefore won't work as expected

