### PR TITLE
Fix issue with SHIFT + TAB

### DIFF
--- a/src/FocusLoop.vue
+++ b/src/FocusLoop.vue
@@ -81,6 +81,9 @@ export default {
         if (!active) {
           ariaHiddenElements = []
         }
+        if (this.autoFocus) {
+          this.alreadyFocused = active
+        }
       })
     },
 


### PR DESCRIPTION
fix issues https://github.com/vue-a11y/vue-focus-loop/issues/9
If `autoFocus` is enabled, `this.alreadyFocused` will always be false until `this.handleFocusStart` run once and therefore won't work as expected.